### PR TITLE
chore: Correct repo URLs in package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,12 +83,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ospm/eslint-plugin-react-signals-hooks.git"
+    "url": "https://github.com/ospm-app/eslint-plugin-react-signals-hooks.git"
   },
   "bugs": {
-    "url": "https://github.com/ospm/eslint-plugin-react-signals-hooks/issues"
+    "url": "https://github.com/ospm-app/eslint-plugin-react-signals-hooks/issues"
   },
-  "homepage": "https://github.com/ospm/eslint-plugin-react-signals-hooks#readme",
+  "homepage": "https://github.com/ospm-app/eslint-plugin-react-signals-hooks#readme",
   "peerDependencies": {
     "react": "^18.2.0 || ^19.0.0",
     "@types/react": "^18.2.0 || ^19.0.0",


### PR DESCRIPTION
# Pull Request

## 📝 Description

Correct repo URLs, these all 404 from the package page on NPM at the moment.

## Related Issues

N/A

## ✅ Checklist

- [X] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [X] My code follows the project's coding style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added/updated necessary documentation
- [X] All tests pass (`npm test`)
- [X] I have run the linter and fixed any issues (`npm run lint`)

## 🧪 Testing

N/A
